### PR TITLE
Fixed typo in html file for default port and set default port

### DIFF
--- a/fabric-blocks-listener.html
+++ b/fabric-blocks-listener.html
@@ -57,7 +57,7 @@
     </div>
     <div class="form-row">
         <label for="node-input-connectTimeout"><i class="fa fa-clock-o"></i> ConnectTimeout</label>
-        <input type="text" id="node-input-connectTimeout" placeholder="Timeout for peer connection (deault: 3000 ms)">
+        <input type="text" id="node-input-connectTimeout" placeholder="Timeout for peer connection (default: 3000 ms)">
     </div>
     <div class="form-row">
         <label for="node-input-sslCert"><i class="fa fa-certificate"></i> SSLCert</label>

--- a/fabric-blocks-listener.js
+++ b/fabric-blocks-listener.js
@@ -7,7 +7,7 @@ module.exports = function (RED) {
         const flowContext = node.context().flow;
 
         let peerAddress = flowContext.get("fbl.peerAddress");
-        const connectTimeout = flowContext.get("fbl.connectTimeout");
+        const connectTimeout = flowContext.get("fbl.connectTimeout") || 3000;
         const sslCert = flowContext.get("fbl.sslCert");
         const sslHostName = flowContext.get("fbl.sslHostName");
         const username = flowContext.get("fbl.username");


### PR DESCRIPTION
In NodeRed interface, the default port value is not shown due to typo in HTML file - Fixed this.

If the default port value is not given, the listener will fail. So I put a default value in the logic.